### PR TITLE
Java assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,6 @@ checkstyle {
     toolVersion = '8.29'
 }
 
-run{
-    standardInput = System.in
+run {
+    enableAssertions = true
 }

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -34,19 +34,25 @@ public class Parser {
             } else if (cmd.equals("list")) {
                 return new ListCommand();
             } else if (cmd.matches("^done\\s\\d+$")) {
+                assert cmd.length() > 5;
                 int serialNo = Integer.parseInt(cmd.substring(5));
                 return new DoneCommand(serialNo);
             } else if (cmd.matches("^deadline\\s.*\\s/by\\s\\d{4}-\\d{2}-\\d{2}$")) {
-                String[] splitText = cmd.substring(9).split(" /by ");
+                assert cmd.length() > 9;
+                String[] splitText = cmd.substring(9).split("\\s/by\\s");
+                assert splitText.length == 2;
                 Task task = new Deadline(splitText[0].trim(), LocalDate.parse(splitText[1]), false);
                 return new AddCommand(task);
             } else if (cmd.matches("^event\\s.*\\s/at\\s\\d{4}-\\d{2}-\\d{2}$")) {
-                String[] splitText = cmd.substring(6).split(" /at ");
+                assert cmd.length() > 6;
+                String[] splitText = cmd.substring(6).split("\\s/at\\s");
+                assert splitText.length == 2;
                 Task task = new Event(splitText[0].trim(), LocalDate.parse(splitText[1]), false);
                 return new AddCommand(task);
             } else if (cmd.matches("^todo\\s*$")) {
                 throw new DukeException("Sorry Boss, todo must be followed with a description.");
             } else if (cmd.matches("^todo\\s.*$")) {
+                assert cmd.length() > 5;
                 Task task = new ToDo(cmd.substring(5).trim(), false);
                 return new AddCommand(task);
             } else if (cmd.matches("^delete\\s\\d+$")) {


### PR DESCRIPTION
Enable assertions in gradle run task

Enables Java assertions when running the app.

Use Java assert in parse() method in Parser

Command strings should have matched with the RegEx within the if-else blocks. Assumptions of the string length > n must hold true so that .substring(n) does not throw an Exception. Assumptions of the length of the string array after calling split() must also hold true so that array accesses does not throw an Exception.