### PR TITLE
Rename remove method in TaskList to delete

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -54,7 +54,9 @@ public class Duke extends Application {
     }
 
     /**
-     * Starts the Duke application with the UI. Writes to the data file after being closed by the user.
+     * Executes the command received by the UI.
+     *
+     * @param cmd The string command entered by the user.
      */
     public void executeCommand(String cmd) {
         try {

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -15,7 +15,7 @@ public class DeleteCommand extends Command {
 
     @Override
     public void execute(TaskList taskList, Storage storage, UiPane uiPane) throws DukeException {
-        Task task = taskList.remove(serialNo);
+        Task task = taskList.delete(serialNo);
         storage.write(taskList.getTasks());
         uiPane.showTaskList(taskList.getTasks());
         uiPane.showMessage(

--- a/src/main/java/duke/storage/TaskList.java
+++ b/src/main/java/duke/storage/TaskList.java
@@ -32,12 +32,12 @@ public class TaskList {
     }
 
     /**
-     * Removes a task by its serial number from the list. Returns the task that was removed.
+     * Deletes a task by its serial number from the list. Returns the task that was removed.
      *
      * @param serialNo The serial number of the task to remove.
      * @return The task that was removed.
      */
-    public Task remove(int serialNo) throws DukeException {
+    public Task delete(int serialNo) throws DukeException {
         if (tasks.isEmpty()) {
             throw new DukeException("Sorry Boss, there is no task to remove.");
         } else if (serialNo < 1 || serialNo > tasks.size()) {


### PR DESCRIPTION
Delete command is used in App and other classes use the term delete. Renaming to delete ensures consistency.

Broke up parse method in Parser

parse method exceeded 30 LOC previously. Broke it up into several private methods that abstract parsing task commands and special commands.